### PR TITLE
signatureField est un champ de transactionDocument et non transaction…

### DIFF
--- a/src/Request/DocSignatureField.php
+++ b/src/Request/DocSignatureField.php
@@ -3,12 +3,13 @@
 namespace PierreBelin\Universign\Request;
 // require_once dirname(__DIR__) . '/Base.php';
 
-class SignatureField extends Base
+class DocSignatureField extends Base
 {
     protected $attributesTypes = [
         'name' => 'string',
         'page' => 'int',
         'x' => 'int',
-        'y' => 'int'
+        'y' => 'int',
+        'signerIndex' => 'int',
     ];
 }

--- a/src/Request/TransactionDocument.php
+++ b/src/Request/TransactionDocument.php
@@ -21,5 +21,12 @@ class TransactionDocument extends Base
         'name'            => 'string',
         'title'           => 'string',
         'SEPAData' => 'PierreBelin\Universign\Request\SEPAData',
+        'signatureFields' => 'array',
     ];
+
+    public function addSignatureField(DocSignatureField  $docSignatureField)
+    {
+        $this->attributes['signatureFields'][] = $docSignatureField;
+        return $this;
+    }
 }

--- a/src/Request/TransactionSigner.php
+++ b/src/Request/TransactionSigner.php
@@ -15,12 +15,6 @@ class TransactionSigner extends Base
         'successURL' => 'string',
         'cancelURL' => 'string',
         'failURL' => 'string',
-        'signatureFields' => 'array',
     ];
 
-    public function addSignatureField(SignatureField $signatureField)
-    {
-        $this->attributes['signatureFields'][] = $signatureField;
-        return $this;
-    }
 }


### PR DESCRIPTION
Salut, 
Je ne sais pas si l'api a changée depuis que tu as fait ce package. Mais j'ai fait quelques changement basé sur la documentation : 
https://help.universign.com/hc/fr/articles/360000837749-Guide-d-int%C3%A9gration-de-la-signature-%C3%A9lectronique-Universign

A savoir signatureField est un champ de transactionDocument et non plus des signataires.

Du coup j'ai modifié la class DocSignatureField qui doit être initialisée avant TransactionDocument. (pour ton readme).

**Create signature fields**
$signatureField1 = new SignatureField();
$signatureField1->setPage(1)
    ->setX(50)
    ->setY(100)
    ->setSignerIndex(0);


**Get your document   (doit faire appel à la méthode  ->addSignatureField($signatureField1)**
$document = new TransactionDocument();
$document
    ->setContent(file_get_contents('path/to/file/file.pdf'))
     ->addSignatureField($signatureField1) // you can add multiples times ->addSignatureField($signatureField2) etc...
    ->setName('Document name');


**Create signers (ne doit plus faire appel à la méthode  ->addSignatureField($signatureField1)**
$signer = new TransactionSigner();
$signer
    ->setFirstname('Yohann')
    ->setLastname('Bonamy')
    ->setEmailAddress('yohann@humantocomputer.com')
    ->setPhoneNum('0678787878')
//    ->setBirthDate('19900131T00:00:00') // This format is needed yyyymmddT00:00:00 as string for 31/01/1990
    ->setSuccessURL('https://www.universign.eu/fr/sign/success/')
    ->setCancelURL('https://www.universign.eu/fr/sign/cancel/')
    ->setFailURL('https://www.universign.eu/fr/sign/failed/');

